### PR TITLE
Gcc warnings

### DIFF
--- a/src/Subtitles/imageobject.h
+++ b/src/Subtitles/imageobject.h
@@ -79,10 +79,9 @@ private:
     bool forced = false;
     int _forcedFlags;
     int objectId = -1;
+    QVector<ImageObjectFragment> fragments;
     int objVer = 0;
     int objSeq = 0;
-
-    QVector<ImageObjectFragment> fragments;
 };
 
 #endif // IMAGEOBJECT_H

--- a/src/Subtitles/subpicture.h
+++ b/src/Subtitles/subpicture.h
@@ -133,35 +133,39 @@ public:
 
     QVector<int> &objectIDs() { return objectIds; }
 
-    QMap<int, int> forcedFlags;
-
     virtual SubPicture* copy();
 
     QVector<ErasePatch*> erasePatch;
 
 protected:
+    int _screenWidth = 0;
+    int _screenHeight = 0;
+
+    qint64 start = -1;
+    qint64 end = 0;
+
+    int compositionNumber = 0;
+    int numberCompObjects = 0;
+    int numWindows = 0;
+
     int _imageWidth = 0;
     int _imageHeight = 0;
     int xOfs = 0;
     int yOfs = 0;
+
+    bool forced = false;
+    bool decoded = false;
+    bool excluded = false;
 
     QMap<int, QRect> scaledImageRects;
     QMap<int, QRect> imageRects;
     QMap<int, QRect> scaledWindowRects;
     QMap<int, QRect> windowRects;
 
-    int _screenWidth = 0;
-    int _screenHeight = 0;
-    qint64 start = -1;
-    qint64 end = 0;
-    int compositionNumber = 0;
-    int numberCompObjects = 0;
-    int numWindows = 0;
-
-    bool forced = false;
-    bool decoded = false;
-    bool excluded = false;
     QVector<int> objectIds;
+
+public:
+    QMap<int, int> forcedFlags;
 };
 
 #endif // SUBPICTURE_H

--- a/src/Subtitles/subpicturedvd.h
+++ b/src/Subtitles/subpicturedvd.h
@@ -33,13 +33,6 @@ public:
     SubPictureDVD(const SubPictureDVD *other);
     ~SubPictureDVD() { }
 
-    QVector<int> originalAlpha = QVector<int>(4);
-    QVector<int> originalPal = QVector<int>(4);
-    QVector<int> alpha = QVector<int>(4);
-    QVector<int> pal = QVector<int>(4);
-
-    QVector<ImageObjectFragment> rleFragments;
-
     void setOriginal();
     void copyInfo(SubPicture &subPicture);
 
@@ -69,6 +62,13 @@ private:
     int origHeight = 0;
     int origX = 0;
     int origY = 0;
+
+public:
+    QVector<ImageObjectFragment> rleFragments;
+    QVector<int> originalAlpha = QVector<int>(4);
+    QVector<int> originalPal = QVector<int>(4);
+    QVector<int> alpha = QVector<int>(4);
+    QVector<int> pal = QVector<int>(4);
 };
 
 #endif // SUBPICTUREDVD_H

--- a/src/Subtitles/subtitleprocessor.cpp
+++ b/src/Subtitles/subtitleprocessor.cpp
@@ -2438,7 +2438,6 @@ void SubtitleProcessor::readSup()
     {
         if (substream == supBD.data())
         {
-            double srcFps = supBD->getFps(0);
             fpsSrc = supBD->getFps(0);
             fpsSrcCertain = true;
             if (keepFps)

--- a/src/Subtitles/supbd.cpp
+++ b/src/Subtitles/supbd.cpp
@@ -1375,7 +1375,6 @@ Bitmap SupBD::decodeImage(SubPictureBD *subPicture, int transparentIndex)
         int ofs = 0;
         int size = 0;
         int xpos = 0;
-        int line = 0;
 
         // just for multi-packet support, copy all of the image data in one common buffer
         QVector<uchar> buf = QVector<uchar>(imageObject.bufferSize());

--- a/src/Subtitles/supxml.cpp
+++ b/src/Subtitles/supxml.cpp
@@ -380,7 +380,7 @@ bool SupXML::XmlHandler::characters(const QString &ch)
 }
 
 
-bool SupXML::XmlHandler::endElement(const QString &namespaceURI, const QString &localName, const QString &qName)
+bool SupXML::XmlHandler::endElement(const QString const QString &qName)
 {
     XmlState endState = findState(qName.toLower());
     if (state == XmlState::GRAPHIC && endState == XmlState::GRAPHIC)
@@ -390,8 +390,7 @@ bool SupXML::XmlHandler::endElement(const QString &namespaceURI, const QString &
     return true;
 }
 
-bool SupXML::XmlHandler::startElement(const QString &namespaceURI, const QString &localName,
-                                      const QString &qName, const QXmlAttributes &atts)
+bool SupXML::XmlHandler::startElement(const QString &qName, const QXmlAttributes &atts)
 {
     state = findState(qName.toLower());
     QString at;

--- a/src/Subtitles/supxml.h
+++ b/src/Subtitles/supxml.h
@@ -50,8 +50,8 @@ class SupXML : public QObject, public Substream
         XmlHandler(SupXML* parent) { this->parent = parent; }
 
         bool characters(const QString &ch);
-        bool endElement(const QString &namespaceURI, const QString &localName, const QString &qName);
-        bool startElement(const QString &namespaceURI, const QString &localName, const QString &qName, const QXmlAttributes &atts);
+        bool endElement(const QString &qName);
+        bool startElement(const QString &qName, const QXmlAttributes &atts);
 
     private:
 

--- a/src/bdsup2sub.cpp
+++ b/src/bdsup2sub.cpp
@@ -889,7 +889,7 @@ void BDSup2Sub::addCLIOptions()
     options->alias("o", "output");
 }
 
-bool BDSup2Sub::execCLI(int argc, char** argv)
+bool BDSup2Sub::execCLI()
 {
     Redirect_console();
 

--- a/src/bdsup2sub.h
+++ b/src/bdsup2sub.h
@@ -47,7 +47,7 @@ class BDSup2Sub : public QMainWindow
 public:
     explicit BDSup2Sub(QWidget *parent = 0);
     ~BDSup2Sub();
-    bool execCLI(int argc, char** argv);
+    bool execCLI();
 
 public slots:
     void changeWindowTitle(QString newTitle);

--- a/src/editdialog.cpp
+++ b/src/editdialog.cpp
@@ -565,7 +565,7 @@ void EditDialog::on_durationLineEdit_textChanged(const QString &arg1)
     }
 }
 
-void EditDialog::on_xOffsetLineEdit_textChanged(const QString &arg1)
+void EditDialog::on_xOffsetLineEdit_textChanged()
 {
     if (!isReady) return;
 
@@ -608,7 +608,7 @@ void EditDialog::on_xOffsetLineEdit_textChanged(const QString &arg1)
     }
 }
 
-void EditDialog::on_yOffsetLineEdit_textChanged(const QString &arg1)
+void EditDialog::on_yOffsetLineEdit_textChanged()
 {
     if (!isReady) return;
 

--- a/src/editdialog.h
+++ b/src/editdialog.h
@@ -75,8 +75,8 @@ private slots:
     void on_startTimeLineEdit_textChanged(const QString &arg1);
     void on_endTimeLineEdit_textChanged(const QString &arg1);
     void on_durationLineEdit_textChanged(const QString &arg1);
-    void on_xOffsetLineEdit_textChanged(const QString &arg1);
-    void on_yOffsetLineEdit_textChanged(const QString &arg1);
+    void on_xOffsetLineEdit_textChanged();
+    void on_yOffsetLineEdit_textChanged();
 
     void on_startTimeLineEdit_editingFinished();
     void on_endTimeLineEdit_editingFinished();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 
     bool isGUI = argc == 1;
 
-    if (isGUI || !w.execCLI(argc, argv))
+    if (isGUI || !w.execCLI())
     {
 #ifdef Q_OS_WIN
         FreeConsole();


### PR DESCRIPTION
This will fix all -Wreorder, -Wunused-variable and several -Wunused-parameter warnings when building with gcc/g++.
There are remaining -Wunused-parameter warnings that I'm unable to solve without breaking things.
